### PR TITLE
meson64-tools: Update license

### DIFF
--- a/pkgs/misc/meson64-tools/default.nix
+++ b/pkgs/misc/meson64-tools/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://github.com/angerman/meson64-tools";
     description = "Tools for Amlogic Meson ARM64 platforms";
-    license = licenses.unfree; # https://github.com/angerman/meson64-tools/issues/2
+    license = licenses.mit;
     maintainers = with maintainers; [ aarapov ];
   };
 }


### PR DESCRIPTION
Now MIT-licensed! https://github.com/angerman/meson64-tools/commit/e4b580444cb31a43ece14041912e35d6583ae59c

Not sure if you're still maintaining this branch at all, but since it's referenced at least by https://wiki.nixos.org/wiki/NixOS_on_ARM/ODROID-HC4, I figured I'd toss this your way!